### PR TITLE
Compatibility with Flask version >= 2.0.1 as it does not affect proper operation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = { text = "MIT" }
 authors = [{ name = "Tomislav Adamic", email = "tomislav.adamic@gmail.com" }]
 dependencies = [
     "apispec[yaml,marshmallow]",
-    "flask >= 2.3.0",
+    "flask >= 2.0.1",
     "inflection",
     "marshmallow >= 3.18.0",
     "pyyaml",


### PR DESCRIPTION
The goal is to expand the use by more people of the library, as we currently have nothing preventing its use with this Flask version criterion